### PR TITLE
Jakarta migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>io.muserver</groupId>
             <artifactId>mu-server</artifactId>
-            <version>1.1.0</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/hsbc/cranker/mucranker/CrankerMuHandler.java
+++ b/src/main/java/com/hsbc/cranker/mucranker/CrankerMuHandler.java
@@ -4,8 +4,8 @@ import io.muserver.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;

--- a/src/main/java/com/hsbc/cranker/mucranker/CrankerRouterImpl.java
+++ b/src/main/java/com/hsbc/cranker/mucranker/CrankerRouterImpl.java
@@ -168,7 +168,7 @@ class CrankerRouterImpl implements CrankerRouter {
     }
 
     private static void validateIpAddress(IPValidator ipValidator, MuRequest request) {
-        String remoteAddress = request.remoteAddress();
+        String remoteAddress = request.connection().remoteAddress().getAddress().getHostAddress();
         if (!ipValidator.allow(remoteAddress)) {
             String errorMsg = "Fail to establish websocket connection to craker connector because of not supported ip address="
                 + remoteAddress + " the routerName=" + Mutils.htmlEncode(request.headers().get("Route"));

--- a/src/main/java/com/hsbc/cranker/mucranker/CrankerRouterImpl.java
+++ b/src/main/java/com/hsbc/cranker/mucranker/CrankerRouterImpl.java
@@ -4,8 +4,8 @@ import io.muserver.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.ClientErrorException;
-import javax.ws.rs.ForbiddenException;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.ForbiddenException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/com/hsbc/cranker/mucranker/FavIconHandler.java
+++ b/src/main/java/com/hsbc/cranker/mucranker/FavIconHandler.java
@@ -2,7 +2,7 @@ package com.hsbc.cranker.mucranker;
 
 import io.muserver.*;
 
-import javax.ws.rs.NotFoundException;
+import jakarta.ws.rs.NotFoundException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/com/hsbc/cranker/mucranker/ProxyListener.java
+++ b/src/main/java/com/hsbc/cranker/mucranker/ProxyListener.java
@@ -2,7 +2,7 @@ package com.hsbc.cranker.mucranker;
 
 import io.muserver.Headers;
 
-import javax.ws.rs.WebApplicationException;
+import jakarta.ws.rs.WebApplicationException;
 import java.nio.ByteBuffer;
 import java.util.List;
 

--- a/src/main/java/com/hsbc/cranker/mucranker/RouterSocket.java
+++ b/src/main/java/com/hsbc/cranker/mucranker/RouterSocket.java
@@ -4,7 +4,7 @@ import io.muserver.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.WebApplicationException;
+import jakarta.ws.rs.WebApplicationException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;

--- a/src/main/java/com/hsbc/cranker/mucranker/RouterSocketV3.java
+++ b/src/main/java/com/hsbc/cranker/mucranker/RouterSocketV3.java
@@ -4,7 +4,7 @@ import io.muserver.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.WebApplicationException;
+import jakarta.ws.rs.WebApplicationException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/com/hsbc/cranker/mucranker/ProxyListenerTest.java
+++ b/src/test/java/com/hsbc/cranker/mucranker/ProxyListenerTest.java
@@ -14,7 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scaffolding.ClientUtils;
 
-import javax.ws.rs.WebApplicationException;
+import jakarta.ws.rs.WebApplicationException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;


### PR DESCRIPTION
This is for mu-cranker-router 2.0, migrating javax to jakarta as described in https://blogs.oracle.com/javamagazine/post/transition-from-java-ee-to-jakarta-ee