### PR TITLE
Adding withClientIpProvider() for recongnize connector's IP

### DIFF
--- a/src/main/java/com/hsbc/cranker/mucranker/RouterInfo.java
+++ b/src/main/java/com/hsbc/cranker/mucranker/RouterInfo.java
@@ -128,7 +128,7 @@ class RouterInfoImpl implements RouterInfo {
                 ConnectorInstance connectorInstance = instanceMap.get(connectorInstanceID);
                 if (connectorInstance == null) {
                     connectorInstance = new ConnectorInstanceImpl(
-                        routerSocket.serviceAddress().getHostString(),
+                        routerSocket.getClientIp(),
                         connectorInstanceID,
                         new ArrayList<>(),
                         routerSocket.isDarkModeOn(darkHosts));
@@ -153,7 +153,7 @@ class RouterInfoImpl implements RouterInfo {
                     ConnectorInstance connectorInstance = instanceMap.get(connectorInstanceID);
                     if (connectorInstance == null) {
                         connectorInstance = new ConnectorInstanceImpl(
-                            routerSocketV3.serviceAddress().getHostString(),
+                            routerSocketV3.getClientIp(),
                             connectorInstanceID,
                             new ArrayList<>(),
                             false);

--- a/src/main/java/com/hsbc/cranker/mucranker/RouterSocket.java
+++ b/src/main/java/com/hsbc/cranker/mucranker/RouterSocket.java
@@ -30,6 +30,7 @@ class RouterSocket extends BaseWebSocket implements ProxyInfo {
     private final List<ProxyListener> proxyListeners;
     private Runnable onReadyForAction;
     private InetSocketAddress remoteAddress;
+    private final String clientIp;
     private boolean isRemoved;
     private boolean hasResponse;
     private final AtomicLong bytesReceived = new AtomicLong();
@@ -43,7 +44,7 @@ class RouterSocket extends BaseWebSocket implements ProxyInfo {
     private long durationMillis = 0;
     private StringBuilder onTextBuffer;
 
-    RouterSocket(String route, String componentName, WebSocketFarm webSocketFarm, String remotePort, List<ProxyListener> proxyListeners) {
+    RouterSocket(String route, String componentName, WebSocketFarm webSocketFarm, String remotePort, List<ProxyListener> proxyListeners, String clientIp) {
         this.webSocketFarm = webSocketFarm;
         this.route = route;
         this.componentName = componentName;
@@ -51,6 +52,7 @@ class RouterSocket extends BaseWebSocket implements ProxyInfo {
         this.proxyListeners = proxyListeners;
         this.isRemoved = false;
         this.hasResponse = false;
+        this.clientIp = clientIp;
     }
 
     @Override
@@ -276,6 +278,10 @@ class RouterSocket extends BaseWebSocket implements ProxyInfo {
     @Override
     public InetSocketAddress serviceAddress() {
         return remoteAddress;
+    }
+
+    public String getClientIp() {
+        return clientIp;
     }
 
     private void putHeadersTo(CrankerProtocolResponse protocolResponse) {

--- a/src/main/java/com/hsbc/cranker/mucranker/RouterSocketV3.java
+++ b/src/main/java/com/hsbc/cranker/mucranker/RouterSocketV3.java
@@ -42,6 +42,7 @@ class RouterSocketV3 extends BaseWebSocket {
     private final Set<String> doNotProxy;
     private Runnable onReadyForAction;
     private InetSocketAddress remoteAddress;
+    private final String clientIp;
 
     private boolean isRemoved;
 
@@ -51,7 +52,7 @@ class RouterSocketV3 extends BaseWebSocket {
     RouterSocketV3(String route, String componentName, WebSocketFarmV3 webSocketFarmV3,
                    String remotePort, List<ProxyListener> proxyListeners,
                    boolean discardClientForwardedHeaders, boolean sendLegacyForwardedHeaders,
-                   String viaValue, Set<String> doNotProxy) {
+                   String viaValue, Set<String> doNotProxy, String clientIp) {
         this.webSocketFarmV3 = webSocketFarmV3;
         this.route = route;
         this.componentName = componentName;
@@ -62,6 +63,7 @@ class RouterSocketV3 extends BaseWebSocket {
         this.viaValue = viaValue;
         this.doNotProxy = doNotProxy;
         this.isRemoved = false;
+        this.clientIp = clientIp;
     }
 
     public WebsocketSessionState state() {
@@ -552,6 +554,10 @@ class RouterSocketV3 extends BaseWebSocket {
 
     public InetSocketAddress serviceAddress() {
         return remoteAddress;
+    }
+
+    public String getClientIp() {
+        return clientIp;
     }
 
     public String getProtocol() {

--- a/src/test/java/com/hsbc/cranker/mucranker/CrankerRouterRegistrationTest.java
+++ b/src/test/java/com/hsbc/cranker/mucranker/CrankerRouterRegistrationTest.java
@@ -1,23 +1,27 @@
 package com.hsbc.cranker.mucranker;
 
 import com.hsbc.cranker.connector.CrankerConnector;
-import io.muserver.Method;
-import io.muserver.MuServer;
+import io.muserver.*;
 import okhttp3.Response;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.RepetitionInfo;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static com.hsbc.cranker.connector.CrankerConnectorBuilder.CRANKER_PROTOCOL_3;
 import static com.hsbc.cranker.mucranker.BaseEndToEndTest.httpsServerForTest;
 import static com.hsbc.cranker.mucranker.BaseEndToEndTest.preferredProtocols;
 import static com.hsbc.cranker.mucranker.CrankerRouterBuilder.crankerRouter;
 import static io.muserver.MuServerBuilder.httpServer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static scaffolding.Action.swallowException;
 import static scaffolding.ClientUtils.call;
 import static scaffolding.ClientUtils.request;
@@ -90,6 +94,73 @@ public class CrankerRouterRegistrationTest {
             assertThat(resp.code(), is(404));
         }
 
+    }
+
+    @Test
+    public void canUseCustomizedIpProviderToKnowClientIp() {
+        String forValue = "126.0.0.0";
+        ForwardedHeader forwardedHeader = new ForwardedHeader("125.0.0.0", forValue, "forwarded.example.org", "http", null);
+        AtomicReference<String> remoteAddress = new AtomicReference<>();
+
+        crankerRouter = crankerRouter()
+            .withClientIpProvider(MuRequest::clientIP) // this get client IP from forwarded header
+            .withSupportedCrankerProtocols(List.of("cranker_1.0", "cranker_3.0"))
+            .start();
+
+        router = httpsServerForTest()
+            .addHandler((req, res) -> {
+                remoteAddress.set(req.remoteAddress());
+                req.headers().set(HeaderNames.FORWARDED, forwardedHeader.toString());
+                return false;
+            })
+            .addHandler(crankerRouter.createRegistrationHandler()).start();
+
+        target = httpServer()
+            .addHandler(Method.GET, "/route", (request, response, pathParams) -> response.write("something"))
+            .start();
+
+        connector = startConnector("route", List.of(CRANKER_PROTOCOL_3));
+
+        Optional<ConnectorService> service = crankerRouter.collectInfo().service("route");
+        assertThat(service.isPresent(), is(true));
+        List<ConnectorInstance> connectors = service.get().connectors();
+        assertThat(connectors.size(), is(1));
+
+        assertThat(connectors.get(0).ip(), not(remoteAddress.get()));
+        assertThat(connectors.get(0).ip(), is(forValue));
+    }
+
+    @Test
+    public void canUseDefaultMethodToGetClientIp() {
+        String forValue = "126.0.0.0";
+        ForwardedHeader forwardedHeader = new ForwardedHeader("125.0.0.0", forValue, "forwarded.example.org", "http", null);
+        AtomicReference<String> remoteAddress = new AtomicReference<>();
+
+        crankerRouter = crankerRouter()
+            .withSupportedCrankerProtocols(List.of("cranker_1.0", "cranker_3.0"))
+            .start();
+
+        router = httpsServerForTest()
+            .addHandler((req, res) -> {
+                remoteAddress.set(req.remoteAddress());
+                req.headers().set(HeaderNames.FORWARDED, forwardedHeader.toString());
+                return false;
+            })
+            .addHandler(crankerRouter.createRegistrationHandler()).start();
+
+        target = httpServer()
+            .addHandler(Method.GET, "/route", (request, response, pathParams) -> response.write("something"))
+            .start();
+
+        connector = startConnector("route", List.of(CRANKER_PROTOCOL_3));
+
+        Optional<ConnectorService> service = crankerRouter.collectInfo().service("route");
+        assertThat(service.isPresent(), is(true));
+        List<ConnectorInstance> connectors = service.get().connectors();
+        assertThat(connectors.size(), is(1));
+
+        assertThat(connectors.get(0).ip(), not(forValue));
+        assertThat(connectors.get(0).ip(), is(remoteAddress.get()));
     }
 
     private CrankerConnector startConnector(String targetServiceName, List<String> preferredProtocols) {


### PR DESCRIPTION
for connector behind proxy, we can provider a customized implementation for retrieving the ip, e.g. from FORWARDED header. 